### PR TITLE
Add tooltip with full path to #tab-list-active-files tabs

### DIFF
--- a/components/active/init.js
+++ b/components/active/init.js
@@ -761,7 +761,7 @@
 			// For some reason, leaving the leading slash on a path causes the
 			// leading slash to be moved to the end of the element, as in at the
 			// end of the file name and subsequently needs to be removed first.
-			var item = '<li class="draggable" data-path="' + path + '"><a><span class="subtle">' +
+			var item = '<li class="draggable" data-path="' + path + '"><a title="' + path.replace(/^\/+/g, '') + '"><span class="subtle">' +
 				info.directory.replace(/^\/+/g, '') + '/</span>' + info.basename +
 				'</a><i class="close fas fa-times-circle"></i></li>';
 


### PR DESCRIPTION
Problem:
The visible part of the path in a #tab-list-active-files tab may not include any unique data when compared to another file's tab...
"/home/user1/projects/foo/public_html/src/file.name" displays as "blic_html/src/file.name"
"/home/user2/projects/bar/public_html/src/file.name" displays as "blic_html/src/file.name"
"/home/user3/projects/baz/public_html/src/file.name" displays as "blic_html/src/file.name"

Solution:
Added 'title' attribute to #tab-list-active-files tabs so that mouseover of element reveals tooltip displaying full path. Allows a quick way for the user to identify which file tab is which without having to first click on the file tab and then view #current_file at the bottom of the screen