### PR TITLE
fix missing $branch on fetch

### DIFF
--- a/components/codegit/traits/transfer.php
+++ b/components/codegit/traits/transfer.php
@@ -28,7 +28,7 @@ trait Transfer {
 		}
 	}
 
-	public function fetch($remote) {
+	public function fetch($remote, $branch) {
 		$command = "git fetch $remote $branch";
 		$result = $this->execute($command);
 		$result["text"] = implode("\n", $result["data"]);


### PR DESCRIPTION
Since I wonder why fetch does not work, i dig arround int the apache log and found the root cause.
Uncaught ErrorException: Undefined variable: branch in /components/codegit/traits/transfer.php