### PR TITLE
FIX PHP warnings in CodeGit history

### DIFF
--- a/components/codegit/traits/history.php
+++ b/components/codegit/traits/history.php
@@ -17,13 +17,13 @@ trait History {
 
 		$pivot = array();
 		foreach ($result as $i => $item) {
-			$item = explode('\\|', $item);
+			$item = explode('|', $item);
 			$pivot[] = array(
-				"hash" => $item[0],
-				"author" => $item[1],
-				"email" => $item[2],
-				"date" => $item[3],
-				"message" => $item[4]
+				"hash" => $item[0] ?? '',
+				"author" => $item[1] ?? '',
+				"email" => $item[2] ?? '',
+				"date" => $item[3] ?? '',
+				"message" => $item[4] ?? ''
 			);
 		}
 


### PR DESCRIPTION
git log concatenates values via pipe "|" (at least in my case). Also if some array items are empty, git produces warnings, so I added a fallback to empty strings