### PR TITLE
Fixed CodeGit parsing return array from CLI where still missing

### DIFF
--- a/components/codegit/traits/commit.php
+++ b/components/codegit/traits/commit.php
@@ -12,8 +12,8 @@ trait Commit {
 
 		foreach ($files as $file) {
 			$result = $this->add($file);
-			if (!$result) {
-				Common::send("error", i18n("git_addFailed", $file));
+			if ($result["code"] === 0) {
+			    Common::send("error", i18n("git_addFailed", $file) . "\n\n" . implode("\n", $result["text"] ?? []));
 			}
 		}
 
@@ -23,10 +23,10 @@ trait Commit {
 		$result = $this->execute("git commit --author=\"{$confData['name']} <{$confData['email']}>\""
 				. " -m\"" . $message . "\"");
 		
-		if ($result) {
+		if ($result["code"] === 0) {
 			Common::send("success", i18n("git_commit_success"));
 		} else {
-			Common::send("error", i18n("git_commit_failed"));
+			Common::send("error", i18n("git_commit_failed") . "\n\n" . implode("\n", $result["text"] ?? []));
 		}
 	}
 	
@@ -35,21 +35,24 @@ trait Commit {
 
 		foreach ($files as $file) {
 			$result = $this->add($file);
-			if (!$result) {
-				Common::send("error", i18n("git_addFailed", $file));
+			if ($result["code"] === 0) {
+			    Common::send("error", i18n("git_addFailed", $file) . "\n\n" . implode("\n", $result["text"] ?? []));
 			}
 		}
 
 		$confData = file_get_contents(DATA . '/' . SESSION('user') . '/codegit.db.json');
 		$confData = json_decode($confData, TRUE)[0];
 
-		if ($message!=='') $result = $this->execute("git commit --amend --author=\"{$confData['name']} <{$confData['email']}>\"" . " -m\"" . $message . "\"");
-		else $result = $this->execute("git commit --amend --no-edit --author=\"{$confData['name']} <{$confData['email']}>\"");
+		if ($message!=='') {
+		    $result = $this->execute("git commit --amend --author=\"{$confData['name']} <{$confData['email']}>\"" . " -m\"" . $message . "\"");
+		} else {
+		    $result = $this->execute("git commit --amend --no-edit --author=\"{$confData['name']} <{$confData['email']}>\"");
+		}
 		
-		if ($result) {
+		if ($result["code"] === 0) {
 			Common::send("success", i18n("git_amend_success"));
 		} else {
-			Common::send("error", i18n("git_amend_failed"));
+		    Common::send("error", i18n("git_amend_failed") . "\n\n" . implode("\n", $result["text"] ?? []));
 		}
 	}
 }

--- a/components/codegit/traits/history.php
+++ b/components/codegit/traits/history.php
@@ -11,7 +11,9 @@ trait History {
 		}
 
 		$result = $this->execute($cmd);
-		if (!$result) {
+		if ($result["code"] === 0) {
+		    $result = $result["text"];
+		} else {
 			return "Error loading log";
 		}
 

--- a/components/codegit/traits/initialize.php
+++ b/components/codegit/traits/initialize.php
@@ -13,10 +13,10 @@ trait Initialize {
 			$result = $this->execute("git init");
 		}
 
-		if ($result) {
+		if ($result["code"] === 0) {
 			Common::send("success", i18n("git_init_success"));
 		} else {
-			Common::send("error", i18n("git_init_failed"));
+		    Common::send("error", i18n("git_init_failed") . "\n\n" . implode("\n", $result["text"] ?? []));
 		}
 	}
 
@@ -39,10 +39,10 @@ trait Initialize {
 
 		$result = $this->execute($command);
 
-		if ($result) {
+		if ($result["code"] === 0) {
 			Common::send("success", i18n("git_clone_success"));
 		} else {
-			Common::send("error", i18n("git_clone_failed"));
+		    Common::send("error", i18n("git_clone_failed") . "\n\n" . implode("\n", $result["text"] ?? []));
 		}
 	}
 }

--- a/components/codegit/traits/transfer.php
+++ b/components/codegit/traits/transfer.php
@@ -6,17 +6,28 @@ trait Transfer {
 
 	public function push($remote, $branch) {
 		$result = $this->execute("git push $remote $branch");
-		Common::send($result);
+		if ($result["code"] === 0) {
+            Common::send("success", implode("\n", $result["text"]));
+		} else {
+		    Common::send("error", i18n("git_undo_failed") . "\n\n" . implode("\n", $result["text"] ?? []));
+		}
 	}
 
 	public function pull($remote, $branch) {
 		$result = $this->execute("git pull $remote $branch");
-		Common::send($result);
+		if ($result["code"] === 0) {
+		    Common::send("success", implode("\n", $result["text"]));
+		} else {
+		    Common::send("error", i18n("git_undo_failed") . "\n\n" . implode("\n", $result["text"] ?? []));
+		}
 	}
 
 	public function fetch($remote, $branch) {
 		$result = $this->execute("git fetch $remote $branch");
-		Common::send($result);
-		// Common::send("success", ["text" => implode("\n", $result)]);
+		if ($result["code"] === 0) {
+		    Common::send("success", implode("\n", $result["text"]));
+		} else {
+		    Common::send("error", i18n("git_undo_failed") . "\n\n" . implode("\n", $result["text"] ?? []));
+		}
 	}
 }


### PR DESCRIPTION
- I have run across some places, where the result of `$this->execute()` still was not properly parsed via `if($result["code"] === 0)`. Changed these in a similar way to what you have done previously
- In `components/codegit/traits/history.php` the method `untrackedDiff()` was using the `cat` command, which is only available on *nix systems. Replaced it with `more`, which is available in both worlds.