### PR TITLE
Fixed codegit log display bug

### DIFF
--- a/components/codegit/traits/history.php
+++ b/components/codegit/traits/history.php
@@ -12,24 +12,21 @@ trait History {
 
 		$result = $this->execute($cmd);
 		if ($result["code"] === 0) {
-		    $result = $result["text"];
+			$pivot = array();
+			foreach ($result["text"] as $i => $item) {
+				$item = explode('|', $item);
+				$pivot[] = array(
+					"hash" => $item[0] ?? '',
+					"author" => $item[1] ?? '',
+					"email" => $item[2] ?? '',
+					"date" => $item[3] ?? '',
+					"message" => $item[4] ?? ''
+				);
+			}
+			return $pivot;
 		} else {
 			return "Error loading log";
 		}
-
-		$pivot = array();
-		foreach ($result['text'] as $i => $item) {
-			$item = explode('|', $item);
-			$pivot[] = array(
-				"hash" => $item[0] ?? '',
-				"author" => $item[1] ?? '',
-				"email" => $item[2] ?? '',
-				"date" => $item[3] ?? '',
-				"message" => $item[4] ?? ''
-			);
-		}
-
-		return $pivot;
 	}
 
 	public function loadDiff($repo, $path) {


### PR DESCRIPTION
Because $result["text"] is no more defined as array behind $result = $result["text"];