### PR TITLE
Add workflow for automatically building and pushing Docker Images.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,27 @@
+#Run on new commit
+on:
+  push:
+#Naming
+name: Build Docker Image
+run-name: Building Docker Image from commit ${{ github.sha }}
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      #Setup docker stuff (qemu and buildx)
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      #Login to docker hub for building (make sure secrets are set)
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Build and upload
+      - name: Build and Upload
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: hlsiira/atheos:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,8 @@
 #Run on new commit
 on:
   push:
+    branches:
+    - main
 #Naming
 name: Build Docker Image
 run-name: Building Docker Image from commit ${{ github.sha }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      #Download Dockerfile
+      - name: Get Dockerfile
+        uses: actions/checkout@v2.7.0
+        with:
+          repository: Atheos/Atheos-Docker
       # Build and upload
       - name: Build and Upload
         uses: docker/build-push-action@v4


### PR DESCRIPTION
I'll look into seeing if I can have it automatically create tags, but this just rebuilds it and pushes it to Docker Hub when a commit is made.
**IMPORTANT**
You do need to add the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets on this screen in the repository settings page:
![image](https://user-images.githubusercontent.com/47341194/227747916-aafe2e46-b85e-461c-8234-b81d338d42ea.png)
For the DOCKERHUB_TOKEN you need to create a PAT (like for GitHub) on your Docker Hub account. There's a guide [here](https://docs.docker.com/docker-hub/access-tokens/) if you need it.