### PR TITLE
Make cryptic bug obvious when worker unable to start

### DIFF
--- a/components/worker/init.js
+++ b/components/worker/init.js
@@ -64,7 +64,7 @@
 				self.worker = new Worker('components/worker/worker.js');
 				self.worker.onerror = (ev) => {
 					// This should reveal a bug when `/vendor` folder was not provided
-					toast('error', 'Error with worker:' + ev.message);
+					output('error', 'Error with worker:' + ev.message);
 				};
 				return !!self.worker;
 			}

--- a/components/worker/init.js
+++ b/components/worker/init.js
@@ -62,6 +62,10 @@
 		initiateWorker: function() {
 			if (typeof Worker !== 'undefined' && Worker !== null) {
 				self.worker = new Worker('components/worker/worker.js');
+				self.worker.onerror = (ev) => {
+					// This should reveal a bug when `/vendor` folder was not provided
+					toast('error', 'Error with worker:' + ev.message);
+				};
 				return !!self.worker;
 			}
 		},


### PR DESCRIPTION
**Before:** 
Save command silently does nothing if installation was improper

**After:**
Correct message provided