### PR TITLE
Username/Email required for git to work.

### DIFF
--- a/components/codegit/traits/commit.php
+++ b/components/codegit/traits/commit.php
@@ -8,6 +8,15 @@ trait Commit {
 	}
 
 	public function commit($message, $files) {
+		$confData = file_get_contents(DATA . "/users/" . SESSION("user") . "/codegit.db.json");
+		$confData = json_decode($confData, TRUE)[0];
+
+		if (!$confData["name"] || !$confData["email"])
+		{
+			Common::send(500, i18n("git_error_emailRequired"));
+			return;
+		}
+
 		$files = explode(",", $files);
 		
 		foreach ($files as $file) {
@@ -16,9 +25,6 @@ trait Commit {
 			    Common::send(500, i18n("git_addFailed", $file) . "\n\n" . implode("\n", $result["text"] ?? []));
 			}
 		}
-
-		$confData = file_get_contents(DATA . "/users/" . SESSION("user") . "/codegit.db.json");
-		$confData = json_decode($confData, TRUE)[0];
 
 		$result = $this->execute("git commit --author=\"{$confData["name"]} <{$confData["email"]}>\""
 				. " -m\"" . $message . "\"");

--- a/components/codegit/traits/settings.php
+++ b/components/codegit/traits/settings.php
@@ -19,6 +19,7 @@ trait Settings {
 				}
 			}
 
+			// FIXME: could be a race between different users
 			if (isset($settings["local"])) {
 				$this->execute("git config user.name '" . $settings["local"]["name"] . "'");
 				$this->execute("git config user.email '" . $settings["local"]["email"] . "'");

--- a/languages/en.json
+++ b/languages/en.json
@@ -555,6 +555,7 @@
 
 	"git": {
 		"error": {
+			"emailRequired": "You have to provide username and email",
 			"noRepo": "Git repo not found.",
 			"noPath": "Missing path.",
 			"noRepoFileMsg": "Missing repo, file or message.",


### PR DESCRIPTION
**Before**
If no user and email set for a user git refused to commit with non obvious message.

**After**
A message from codegit component that user have to setup username and email.